### PR TITLE
calltoolbar fix

### DIFF
--- a/client/components/Calls/Calls.js
+++ b/client/components/Calls/Calls.js
@@ -88,11 +88,11 @@ export default class Calls extends Component {
   }
 
   clearActiveCall = () => {
-    this.setState({ activeCall: null, activeElement: null });
+    this.setState({ activeCall: null, activeChild: null });
   }
 
   setActiveCall = (call, el) => {
-    this.setState({ activeCall: call, activeElement: el });
+    this.setState({ activeCall: call, activeChild: el });
   }
 
   setCallsHistory = (el) => {

--- a/client/components/Calls/Calls.spec.js
+++ b/client/components/Calls/Calls.spec.js
@@ -54,4 +54,33 @@ describe('components/Calls', () => {
       expect(rendered).to.have.exactly(1).descendants('a[data-test="Calls-remove"]');
     });
   });
+
+  describe('actions', () => {
+    let rendered;
+
+    before(() => {
+      const calls = [
+        { callNo: 0, name: 'eth_call', params: '', response: '' },
+        { callNo: 1, name: 'eth_sendTransaction', params: '', response: '' }
+      ];
+
+      rendered = shallow(<Calls calls={calls} />);
+    });
+
+    it('sets the activeCall & activeChild state via setActiveCall', () => {
+      rendered.instance().setActiveCall('dummyActiveCall', 'dummyActiveChild');
+
+      expect(rendered).to.have.state('activeCall', 'dummyActiveCall');
+      expect(rendered).to.have.state('activeChild', 'dummyActiveChild');
+    });
+
+    it('clears the activeCall & activeChild state via clearActiveCall', () => {
+      rendered.instance().setActiveCall('dummyActiveCall', 'dummyActiveChild');
+      expect(rendered).to.have.state('activeCall', 'dummyActiveCall');
+      rendered.instance().clearActiveCall();
+
+      expect(rendered).to.have.state('activeCall', null);
+      expect(rendered).to.have.state('activeChild', null);
+    });
+  });
 });

--- a/client/components/Calls/Calls.spec.js
+++ b/client/components/Calls/Calls.spec.js
@@ -57,6 +57,7 @@ describe('components/Calls', () => {
 
   describe('actions', () => {
     let rendered;
+    let instance;
 
     before(() => {
       const calls = [
@@ -65,19 +66,20 @@ describe('components/Calls', () => {
       ];
 
       rendered = shallow(<Calls calls={calls} />);
+      instance = rendered.instance();
     });
 
-    it('sets the activeCall & activeChild state via setActiveCall', () => {
-      rendered.instance().setActiveCall('dummyActiveCall', 'dummyActiveChild');
+    it('sets state via setActiveCall', () => {
+      instance.setActiveCall('dummyActiveCall', 'dummyActiveChild');
 
       expect(rendered).to.have.state('activeCall', 'dummyActiveCall');
       expect(rendered).to.have.state('activeChild', 'dummyActiveChild');
     });
 
-    it('clears the activeCall & activeChild state via clearActiveCall', () => {
-      rendered.instance().setActiveCall('dummyActiveCall', 'dummyActiveChild');
+    it('clears state via clearActiveCall', () => {
+      instance.setActiveCall('dummyActiveCall', 'dummyActiveChild');
       expect(rendered).to.have.state('activeCall', 'dummyActiveCall');
-      rendered.instance().clearActiveCall();
+      instance.clearActiveCall();
 
       expect(rendered).to.have.state('activeCall', null);
       expect(rendered).to.have.state('activeChild', null);


### PR DESCRIPTION
https://github.com/ethcore/eth-node-status-page/issues/164

Late rename refactor broke naming. 

Tests added to ensure setActiveCall & clearActiveCall does the right thing.